### PR TITLE
Replacing UIWebView and bug fix

### DIFF
--- a/biliATV.xcodeproj/project.pbxproj
+++ b/biliATV.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		16055A651F285264000F3AF7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16055A641F285264000F3AF7 /* AppDelegate.swift */; };
 		16055A691F285264000F3AF7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 16055A681F285264000F3AF7 /* Assets.xcassets */; };
+		C130C9FA213641900077492A /* BILWebView.m in Sources */ = {isa = PBXBuildFile; fileRef = C130C9F9213641900077492A /* BILWebView.m */; };
 		DC12AD871FE04B2E00041E95 /* MHURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC12AD861FE04B2E00041E95 /* MHURLProtocol.swift */; };
 		DCC008111FC095DE005F223C /* DanMuPlayer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC8A10751FC0841E0021FF00 /* DanMuPlayer.framework */; };
 		DCC008121FC095DE005F223C /* DanMuPlayer.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DC8A10751FC0841E0021FF00 /* DanMuPlayer.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -52,6 +53,8 @@
 		16055A641F285264000F3AF7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		16055A681F285264000F3AF7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		16055A6A1F285264000F3AF7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C130C9F8213641900077492A /* BILWebView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BILWebView.h; sourceTree = "<group>"; };
+		C130C9F9213641900077492A /* BILWebView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BILWebView.m; sourceTree = "<group>"; };
 		DC12AD861FE04B2E00041E95 /* MHURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MHURLProtocol.swift; sourceTree = "<group>"; };
 		DC4769251FBC31AA00EC6FDD /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
 		DC4769271FBC31B500EC6FDD /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
@@ -119,6 +122,8 @@
 				DC8A106E1FC0841D0021FF00 /* DanMuPlayer.xcodeproj */,
 				16055A641F285264000F3AF7 /* AppDelegate.swift */,
 				DCE10F711FA725EC00DF6AAC /* biliModel.swift */,
+				C130C9F8213641900077492A /* BILWebView.h */,
+				C130C9F9213641900077492A /* BILWebView.m */,
 				16055A681F285264000F3AF7 /* Assets.xcassets */,
 				16055A6A1F285264000F3AF7 /* Info.plist */,
 				16055A661F285264000F3AF7 /* Supporting Files */,
@@ -263,6 +268,7 @@
 				DC12AD871FE04B2E00041E95 /* MHURLProtocol.swift in Sources */,
 				16055A651F285264000F3AF7 /* AppDelegate.swift in Sources */,
 				DCE10F721FA725EC00DF6AAC /* biliModel.swift in Sources */,
+				C130C9FA213641900077492A /* BILWebView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/biliATV/AppDelegate.swift
+++ b/biliATV/AppDelegate.swift
@@ -16,11 +16,11 @@ import AVFoundation
 var ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3260.2 Safari/537.36"
 
 @UIApplicationMain
-class AppDelegate: UIViewController, UIApplicationDelegate, TVApplicationControllerDelegate,UIWebViewDelegate {
+class AppDelegate: UIViewController, UIApplicationDelegate, TVApplicationControllerDelegate {
     
     var window: UIWindow?
     var appController: TVApplicationController?
-    var webview:UIWebView!
+    var wProxy: webProxy!
 //    var player:SGPlayer!
 
 //    var vlc = VLCVideoView();
@@ -29,7 +29,6 @@ class AppDelegate: UIViewController, UIApplicationDelegate, TVApplicationControl
     
     
     
-    var bili:biliModel!
     var tvJsContext: JSContext!
 
     
@@ -95,67 +94,12 @@ class AppDelegate: UIViewController, UIApplicationDelegate, TVApplicationControl
         UserDefaults.standard.register(defaults: ["UserAgent": ua])
         UserDefaults.standard.synchronize()
         
-        let webViewClass : AnyObject.Type = NSClassFromString("UIWebView")!
-        let webViewObject : NSObject.Type = webViewClass as! NSObject.Type
-    
+        wProxy = webProxy.init()
         
-        webview = webViewObject.init() as! UIWebView
-//        webview.bounds = UIScreen.main.bounds;
-
-        
-
-        
-        bili = biliModel(webview)
-        let cacheHack:urlCacheHack = urlCacheHack.init()
-        cacheHack.setModel(bili)
-        URLCache.shared  = cacheHack
-        
-        URLProtocol.registerClass(MHURLProtocol.self)
-        
-        
-        webview.delegate = self;
-        webview.frame = UIScreen.main.bounds
-        
-        
-//        let url = URL(string: "https://www.bilibili.com/video/av14356253/")
-//        let request = URLRequest.init(url: url!)
-//        self.webview.loadRequest(request);
-        
-        
-        self.view.addSubview(webview as! UIView)
-
-        
-
-        
-        
-        
-//        self.player = SGPlayer.init()
-//
-//        self.player.view.frame = self.view.frame
-//        self.player.replaceVideo(with: URL(string: "http://www.sample-videos.com/video/flv/720/big_buck_bunny_720p_1mb.flv"));
-//        self.player.play()
-   
-        
-        //self.player.decoder = SGPlayerDecoder.byFFmpeg()
-//        self.player.view.frame = self.view.frame
-        
-//        self.player.tap
-        //UIViewController
-//        appController?.navigationController.pushViewController(UIViewController, animated: <#T##Bool#>)(self.player., animated: true)
+        self.window!.addSubview(wProxy.webview)
         
         return true
     }
-    
-    public func webViewDidStartLoad(_ webView: UIWebView){
-        return bili!.webViewDidStartLoad(webview)
-    }
-    
-    public func webViewDidFinishLoad(_ webview: UIWebView){
-        return bili!.webViewDidFinishLoad(webview)
-    }
-    
-  
-    
     
     func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
@@ -232,7 +176,7 @@ class AppDelegate: UIViewController, UIApplicationDelegate, TVApplicationControl
             
             
 //            self.Scallback = callback;
-            self.bili.getAvData(aid,page: page){
+            self.wProxy.bili.getAvData(aid,page: page){
                     data in
                 let _data = data;
                 let dataDic = _data._dic;
@@ -299,6 +243,38 @@ class AppDelegate: UIViewController, UIApplicationDelegate, TVApplicationControl
 //        self.tvJsContext.evaluateScript("run();");
 
 
+    }
+}
+
+@objc class webProxy: NSObject {
+    var webview:BILWebView!
+    var bili:biliModel!
+    
+    override init() {
+        webview = BILWebView.init()
+        
+        bili = biliModel(webview)
+        let cacheHack:urlCacheHack = urlCacheHack.init()
+        cacheHack.setModel(bili)
+        URLCache.shared = cacheHack
+        
+        URLProtocol.registerClass(MHURLProtocol.self)
+        
+        super.init()
+        
+        webview.setDelegate(self);
+    }
+    
+    @objc public func webViewDidStartLoad(_ webView: BILWebView){
+        return bili!.webViewDidStartLoad(webview)
+    }
+    
+    @objc public func webViewDidFinishLoad(_ webview: BILWebView){
+        return bili!.webViewDidFinishLoad(webview)
+    }
+    
+    @objc public func webView(_ webView: BILWebView, didFailLoadWithError error: Error){
+        return bili!.webViewDidFinishLoad(webview)
     }
 }
 

--- a/biliATV/BILWebView.h
+++ b/biliATV/BILWebView.h
@@ -1,0 +1,35 @@
+//
+//  BILWebView.h
+//  biliATV
+//
+//  Created by Xummer on 2018/8/29.
+//  Copyright © 2018 xioxin. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface BILWebView : UIView
+@property (nonatomic, strong) id realView;
+
+- (void)setDelegate:(id)delegate;
+
+- (id)delegate;
+
+- (UIScrollView *)scrollView;
+
+- (void)loadRequest:(NSURLRequest *)request;
+
+- (void)loadHTMLString:(NSString *)string baseURL:(nullable NSURL *)baseURL;
+
+- (NSURLRequest *)request;
+
+- (BOOL)isLoading;
+
+- (void)reload;
+- (void)stopLoading;
+
+- (void)goBack;
+- (void)goForward;
+
+- (NSString *)stringByEvaluatingJavaScriptFromString:(NSString *)script;
+@end

--- a/biliATV/BILWebView.m
+++ b/biliATV/BILWebView.m
@@ -1,0 +1,98 @@
+//
+//  BILWebView.m
+//  biliATV
+//
+//  Created by Xummer on 2018/8/29.
+//  Copyright © 2018 xioxin. All rights reserved.
+//
+
+#import "BILWebView.h"
+#import <objc/runtime.h>
+#import "biliATV-Swift.h"
+
+@interface BILWebView ()
+@property (nonatomic, weak) id mDelegate;
+@end
+
+@implementation BILWebView
+
+- (instancetype)init {
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+    
+    Class myClazz = NSClassFromString(@"UIWebView");
+    
+    _realView = [[myClazz alloc] init];
+    
+    [self addSubview:_realView];
+    
+    return self;
+}
+
+- (void)setDelegate:(id)delegate {
+    self.mDelegate = delegate;
+    [[self class] addProtocolToClass:[self class]];
+    [self.realView performSelector:@selector(setDelegate:) withObject:self];
+}
+
+- (id)delegate {
+    return _mDelegate;
+}
+
+- (id)forwardingTargetForSelector:(SEL)aSelector {
+    if ([self respondsToSelector:aSelector]) {
+        return self;
+    }
+    else {
+        return self.realView;
+    }
+}
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)selector {
+    // We only get here if `forwardingTargetForSelector:` returns nil.
+    // In that case, our weak target has been reclaimed. Return a dummy method signature to keep `doesNotRecognizeSelector:` from firing.
+    // We'll emulate the Obj-c messaging nil behavior by setting the return value to nil in `forwardInvocation:`, but we'll assume that the return value is `sizeof(void *)`.
+    // Other libraries handle this situation by making use of a global method signature cache, but that seems heavier than necessary and has issues as well.
+    // See https://www.mikeash.com/pyblog/friday-qa-2010-02-26-futures.html and https://github.com/steipete/PSTDelegateProxy/issues/1 for examples of using a method signature cache.
+    if ([self respondsToSelector:selector]) {
+        return [super methodSignatureForSelector:selector];
+    }
+    else {
+        return [self.realView methodSignatureForSelector:selector];
+    }
+    
+}
+
+- (void)webViewDidStartLoad:(id)webView {
+    webProxy *del = self.mDelegate;
+    if (del) {
+        [del webViewDidStartLoad:self];
+    }
+}
+
+- (void)webViewDidFinishLoad:(id)webView {
+    webProxy *del = self.mDelegate;
+    if (del) {
+        [del webViewDidFinishLoad:self];
+    }
+}
+
+- (void)webView:(id)webView didFailLoadWithError:(NSError *)error {
+    webProxy *del = self.mDelegate;
+    if (del) {
+        [del webView:self didFailLoadWithError:error];
+    }
+}
+
++ (void)addProtocolToClass:(Class)cls {
+    if (!cls) {
+        return;
+    }
+    Protocol *protocol = objc_getProtocol([@"UIWebViewDelegate" UTF8String]);
+    if (protocol) {
+        class_addProtocol(cls, protocol);
+    }
+}
+@end

--- a/biliATV/Bridging-Header.h
+++ b/biliATV/Bridging-Header.h
@@ -1,1 +1,2 @@
 #import <DanMuPlayer.h>
+#import "BILWebView.h"

--- a/biliATV/biliModel.swift
+++ b/biliATV/biliModel.swift
@@ -508,7 +508,18 @@ class urlCacheHack : URLCache {
                 var playData = biliPlayDataModel()
                 
                 if let playDataJsonD = playDataRew as? Dictionary<String, Any> {
-                    let playDataD = playDataJsonD["data"] as? Dictionary<String, Any> ?? [:]
+                    // 番剧
+                    // https://bangumi.bilibili.com/player/web_api/v2/playurl?cid=53331296&appkey=84956560bc028eb7&otype=json&type=&quality=0&module=bangumi&season_type=1&qn=0&sign=55b1f426baa5631df2c4cef3e3ea4862
+                    // 动态
+                    // https://api.bilibili.com/x/player/playurl?avid=30169749&cid=52604596&qn=0&type=mp4&otype=json
+                    
+                    var playDataD: Dictionary<String, Any>
+                    if let mDataD = playDataJsonD["data"] as? Dictionary<String, Any> {
+                        playDataD = mDataD
+                    }
+                    else {
+                        playDataD = playDataJsonD
+                    }
                     
                     playData.cid = Int(cid) ?? 0;
                     playData.from   = playDataD["from"] as? String ?? ""

--- a/biliATV/biliModel.swift
+++ b/biliATV/biliModel.swift
@@ -15,9 +15,9 @@ class biliModel{
     var cid2AidAndPage = Dictionary<Int,Array<Int>>();
     
     
-    var webView:UIWebView!
+    var webView:BILWebView!
 
-    init(_ thisWebView:UIWebView){
+    init(_ thisWebView:BILWebView){
         webView = thisWebView;
     }
     
@@ -55,7 +55,7 @@ class biliModel{
     
     
     
-    public func webViewDidStartLoad(_ webview: UIWebView){
+    public func webViewDidStartLoad(_ webview: BILWebView){
         print("👉 WEB START ");
         
 
@@ -86,9 +86,9 @@ this.isTypeSupported = window.MediaSource.isTypeSupported;
         return link
     }
     
-    public func webViewDidFinishLoad(_ webview: UIWebView){
+    public func webViewDidFinishLoad(_ webview: BILWebView){
 
-        if (webview.isLoading) {
+        if (webview.isLoading()) {
             print("🈲️ 301");
             return;
         }


### PR DESCRIPTION
- 更新 DanMuPlayer 到最新版本，修复在 XCode 9 上无法编译的问题。
- 通过消息转发调用 UIWebView 的方法，不在需要修改 XCode 文件；  PS：没有TV真机，只在模拟器上测试通过😂
- 修复因动态和番剧返回的 JSON 格式不一致导致番剧无法播放的问题。
    - 番剧  https://bangumi.bilibili.com/player/web_api/v2/playurl?cid=53331296&appkey=84956560bc028eb7&otype=json&type=&quality=0&module=bangumi&season_type=1&qn=0&sign=55b1f426baa5631df2c4cef3e3ea4862
    - 动态  https://api.bilibili.com/x/player/playurl?avid=30169749&cid=52604596&qn=0&type=mp4&otype=json